### PR TITLE
add workflow_dispatch trigger to BuildAndPublish

### DIFF
--- a/.github/workflows/BuildAndPublish.yml
+++ b/.github/workflows/BuildAndPublish.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # allows the workflow to be manually executed any time
+  workflow_dispatch:
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
allows the workflow to be manually executed any time

Signed-off-by: Lee Surprenant <lmsurpre@merative.com>